### PR TITLE
Find selectors with-in context of container

### DIFF
--- a/jquery.nearest.js
+++ b/jquery.nearest.js
@@ -54,7 +54,7 @@
 		}
 
 		// Get elements and work out x/y points
-		var $all = $(selector),
+		var $all = $container.find(selector),
 			cache = [],
 			furthest = !!options.furthest,
 			checkX = !!options.checkHoriz,


### PR DESCRIPTION
I'm using this for a CKEditor plugin and I couldn't for the life of me figure out why I couldn't get this plugin to work. It turns out that the following didn't have any context for where these elements were:

``` js
var $all = $(selector)
```

I have the plugin loaded on the actual page (that has jQuery and the plugin). The CKEditor DOM instance (iframe) falls outside the scope of the jQuery document, however. So when I was selecting my elements, it couldn't find the ones inside my CKEditor instance; it would only search the parent DOM. Changing it to the following fixes this:

``` js
var $all = $container.find(selector)
```
