### PR TITLE
Added 2 new options: direction constrains and sorting by distance

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,6 +194,19 @@ var $closestToRegion = $set.nearest({x: 300, y: 100, w: 200, h: 200});
 				<dd class="type">DOM node or jQuery selector &ndash; default <code>document</code></dd>
 				<dd>Acts as a root node, so that only elements within the container will be matched.<br>
 					Also used with percentage options for <code>x</code>, <code>y</code>, <code>w</code> and <code>h</code> &ndash; the top left corner of the container is 0%, the bottom right corner is 100%.</dd>
+
+				<dt><code>directionConstraints</code></dt>
+				<dd class="type">String array &ndash; default <code>empty</code></dd>
+				<dd>A list of directions to limit the search. Available values:
+					<code>left</code>,<code>right</code>,<code>top</code>,<code>bottom</code><br/>
+					Example: <code>['left','top'] will search only to the top left of object.<br/>
+					This only works for Single Element operations</dd>
+
+				<dt><code>sort</code></dt>
+				<dd class="type">String &ndash; default <code>empty</code></dd>
+				<dd>Sorts results based on distance, defaults to no sorting which is DOM order.<br/>
+					Available options: <code>nearest</code> or <code>furthest</code></dd>
+
 			</dl>
 			<dl class="deprecated">
 				<dt><code>checkHoriz</code></dt>

--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@ var $closestToRegion = $set.nearest({x: 300, y: 100, w: 200, h: 200});
 				<dd class="type">String array &ndash; default <code>empty</code></dd>
 				<dd>A list of directions to limit the search. Available values:
 					<code>left</code>,<code>right</code>,<code>top</code>,<code>bottom</code><br/>
-					Example: <code>['left','top'] will search only to the top left of object.<br/>
+					Example: <code>['left','top']</code> will search only to the top left of object.<br/>
 					This only works for Single Element operations</dd>
 
 				<dt><code>sort</code></dt>

--- a/test/nearest_test.js
+++ b/test/nearest_test.js
@@ -400,4 +400,22 @@
 		assertSet($touching, 0, {suffix: 'for touching'});
 	});
 
+	test('option: directionConstraints', 4, function() {
+		var $elem = $('#basic-ref');
+		var $nearestTopLeft  = $elem.nearest( '.corner', {directionConstraints: ['left', 'top']});
+		var $furthestBottomRight = $elem.furthest( '.corner', {directionConstraints: ['bottom', 'right']});
+
+		assertSet($nearestTopLeft,  1, {suffix: 'for ["left", "top"]'},  'top-left');
+		assertSet($furthestBottomRight,  1, {suffix: 'for ["bottom", "right"]'},  'bottom-right');
+	});
+
+	test('option: sort', 10, function () {
+		var $elem = $('#basic-ref');
+		var $sortedNearest  = $elem.nearest('.basic-group', {sort: 'nearest', tolerance: 300});
+		var $sortedFurthest = $elem.nearest('.basic-group', {sort: 'furthest', tolerance: 300});
+
+		assertSet($sortedNearest,  4, {suffix: 'for nearest'},  'basic-touching', 'basic-nearest', 'basic-mid', 'basic-furthest');
+		assertSet($sortedFurthest, 4, {suffix: 'for furthest'}, 'basic-furthest', 'basic-mid', 'basic-nearest', 'basic-touching');
+	});
+
 }(jQuery));


### PR DESCRIPTION
This PR solves #20 and overlaps with PR #22 (but offers more functionality)

Added a new option called `directionConstraints` that takes an array of directions and filters the results to those that only appear in all the directions specified. This option will only work for Single Element Operations and gets ignored for anything else.  Available directions: `left`,`right`,`top`,`bottom`

``` javascript
//Find the nearest .basic elements that are in the top left of $elem
$elem.nearest('.basic', { directionConstraints: ['left', 'top'] });
```

Added another new option called `sort` that takes a sorting order, `nearest` or `furthest`, and sorts the results based on their distance instead of the order they appear on the DOM.

``` javascript
//Get the furthest elements with 100px tolerance and sort by nearest (cause why not)
$elem.furthest('.basic', { sort: 'nearest', tolerance: 100 });
```

P.s: Nice testing setup. Was easy to hook into and add more tests
